### PR TITLE
Token and Certificate Endpoint Authorization

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,7 +9,10 @@ graphQLSchema('./test/fixtures/petstore.json').then(schema => {
     return {
       schema,
       context: {
-        GQLProxyBaseUrl: 'http://petstore.swagger.io/v2'
+        GQLProxyBaseUrl: 'http://petstore.swagger.io/v2',
+        //BearerToken: 'Bearer xxxx',
+        //PfxCertFile: __dirname + '/path/to/cert.pfx',
+        //PfxPassphraseFile: __dirname + '/path/to/passphrase.p12',
       },
       graphiql: true
     };

--- a/lib/index.js
+++ b/lib/index.js
@@ -47,6 +47,32 @@ function resolver(endpoint) {
     const req = endpoint.request(args, {
       baseUrl: opts.GQLProxyBaseUrl
     });
+
+    req.headers.Accept = 'application/json';
+
+    // if Bearer token provided, include that
+    if(opts.BearerToken){
+      req.headers.Authorization = opts.BearerToken;
+    }
+
+    // if pfx certificate and passphrase files provided, add those in
+    if(opts.PfxCertFile && opts.PfxPassphraseFile) {
+      req.agentOptions = {
+        pfx: fs.readFileSync(opts.PfxCertFile),
+        passphrase: fs.readFileSync(opts.PfxPassphraseFile, { encoding: 'utf8' }),
+        securityOptions: 'SSL_OP_NO_SSLv3'
+      };
+    }
+
+    // add in crt/key files if provided
+    if(opts.CrtFile && opts.KeyFile) {
+      req.agentOptions = {
+        cert: fs.readFileSync(opts.CrtFile),
+        key: fs.readFileSync(opts.KeyFile),
+        securityOptions: 'SSL_OP_NO_SSLv3'
+      }
+    }
+
     return rp(req).then(res => {
       return JSON.parse(res);
     }).catch(e => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const fs = requier('fs');
 const rp = require('request-promise');
 const {GraphQLSchema, GraphQLObjectType} = require('graphql');
 const {getAllEndPoints, loadSchema} = require('./swagger');

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const fs = requier('fs');
+const fs = require('fs');
 const rp = require('request-promise');
 const {GraphQLSchema, GraphQLObjectType} = require('graphql');
 const {getAllEndPoints, loadSchema} = require('./swagger');

--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -58,6 +58,7 @@ function getAllEndPoints(schema) {
         response: getSuccessResponse(obj.responses),
         request: (args, server) => {
           const url = `${server.baseUrl}${path}`;
+          obj.parameters = obj.parameters || [];
           return getRequestOptions(obj, {
             request: args,
             url,


### PR DESCRIPTION
Adds options to be able to pass a Bearer Token or client certificate (pfx/cer) to the endpoint for authorization.  Also fixes a strange bug with getRequestOptions where an endpoint with no parameters throws and error.