### PR TITLE
allow circular references, use definition types, update test framework

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,6 +35,8 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var schemaFromEndpoints = function schemaFromEndpoints(endpoints) {
   var proxyUrl = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
 
+  var gqlTypes = {};
+
   var rootType = new _graphql.GraphQLObjectType({
     name: 'Query',
     fields: function fields() {
@@ -43,7 +45,7 @@ var schemaFromEndpoints = function schemaFromEndpoints(endpoints) {
           type: new _graphql.GraphQLObjectType({
             name: 'viewer',
             fields: function fields() {
-              var queryFields = getQueriesFields(endpoints, false, proxyUrl);
+              var queryFields = getQueriesFields(endpoints, false, gqlTypes, proxyUrl);
               if (!(0, _keys2.default)(queryFields).length) {
                 throw new Error('Did not find any GET endpoints');
               }
@@ -62,7 +64,7 @@ var schemaFromEndpoints = function schemaFromEndpoints(endpoints) {
     query: rootType
   };
 
-  var mutationFields = getQueriesFields(endpoints, true, proxyUrl);
+  var mutationFields = getQueriesFields(endpoints, true, gqlTypes, proxyUrl);
   if ((0, _keys2.default)(mutationFields).length) {
     graphQLSchema.mutation = new _graphql.GraphQLObjectType({
       name: 'Mutation',
@@ -76,7 +78,7 @@ var schemaFromEndpoints = function schemaFromEndpoints(endpoints) {
 
 var resolver = function resolver(endpoint, proxyUrl) {
   return function () {
-    var _ref = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee(_, args, opts) {
+    var _ref = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee(_, args, opts) {
       var proxy, req, res;
       return _regenerator2.default.wrap(function _callee$(_context) {
         while (1) {
@@ -109,16 +111,16 @@ var resolver = function resolver(endpoint, proxyUrl) {
   }();
 };
 
-var getQueriesFields = function getQueriesFields(endpoints, isMutation, proxyUrl) {
+var getQueriesFields = function getQueriesFields(endpoints, isMutation, gqlTypes, proxyUrl) {
   return (0, _keys2.default)(endpoints).filter(function (typeName) {
     return !!endpoints[typeName].mutation === !!isMutation;
   }).reduce(function (result, typeName) {
     var endpoint = endpoints[typeName];
-    var type = (0, _typeMap.createGQLObject)(endpoint.response, typeName, false);
+    var type = (0, _typeMap.createGQLObject)(endpoint.response, typeName, false, gqlTypes);
     var gType = {
       type: type,
       description: endpoint.description,
-      args: (0, _typeMap.mapParametersToFields)(endpoint.parameters, typeName),
+      args: (0, _typeMap.mapParametersToFields)(endpoint.parameters, typeName, gqlTypes),
       resolve: resolver(endpoint, proxyUrl)
     };
     result[typeName] = gType;
@@ -127,7 +129,7 @@ var getQueriesFields = function getQueriesFields(endpoints, isMutation, proxyUrl
 };
 
 var build = function () {
-  var _ref2 = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee2(swaggerPath) {
+  var _ref2 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee2(swaggerPath) {
     var proxyUrl = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
     var swaggerSchema, endpoints, schema;
     return _regenerator2.default.wrap(function _callee2$(_context2) {

--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -46,9 +46,11 @@ var getSuccessResponse = function getSuccessResponse(responses) {
 };
 
 var loadSchema = exports.loadSchema = function loadSchema(pathToSchema) {
-  var schema = _jsonSchemaRefParser2.default.dereference(pathToSchema);
-  __schema = schema;
-  return schema;
+  var schemaPromise = _jsonSchemaRefParser2.default.bundle(pathToSchema).then(function (schema) {
+    __schema = schema;
+    return schema;
+  });
+  return schemaPromise;
 };
 
 var replaceOddChars = function replaceOddChars(str) {
@@ -56,7 +58,7 @@ var replaceOddChars = function replaceOddChars(str) {
 };
 
 /**
- * Going throw schema and grab routes
+ * Go through schema and grab routes
  */
 var getAllEndPoints = exports.getAllEndPoints = function getAllEndPoints(schema) {
   var allTypes = {};

--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -5,6 +5,10 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.getAllEndPoints = exports.loadSchema = exports.getSchema = undefined;
 
+var _typeof2 = require('babel-runtime/helpers/typeof');
+
+var _typeof3 = _interopRequireDefault(_typeof2);
+
 var _keys = require('babel-runtime/core-js/object/keys');
 
 var _keys2 = _interopRequireDefault(_keys);
@@ -57,11 +61,32 @@ var replaceOddChars = function replaceOddChars(str) {
   return str.replace(/[^_a-zA-Z0-9]/g, '_');
 };
 
+var getServerPath = function getServerPath(schema) {
+  var server = schema.servers && Array.isArray(schema.servers) ? schema.servers[0] : schema.servers;
+  if (!server) {
+    return undefined;
+  } else if (typeof server === 'string') {
+    return server;
+  }
+  var url = server.url;
+  if (server.variables) {
+    (0, _keys2.default)(server.variables).forEach(function (variable) {
+      var value = server.variables[variable];
+      if ((typeof value === 'undefined' ? 'undefined' : (0, _typeof3.default)(value)) === 'object') {
+        value = value.default || value.enum[0];
+      }
+      url = url.replace('{' + variable + '}', value);
+    });
+  }
+  return url;
+};
+
 /**
  * Go through schema and grab routes
  */
 var getAllEndPoints = exports.getAllEndPoints = function getAllEndPoints(schema) {
   var allTypes = {};
+  var serverPath = getServerPath(schema);
   (0, _keys2.default)(schema.paths).forEach(function (path) {
     var route = schema.paths[path];
     (0, _keys2.default)(route).forEach(function (method) {
@@ -77,6 +102,7 @@ var getAllEndPoints = exports.getAllEndPoints = function getAllEndPoints(schema)
         description: obj.description,
         response: getSuccessResponse(obj.responses),
         request: function request(args, baseUrl) {
+          baseUrl = baseUrl || serverPath; // eslint-disable-line no-param-reassign
           var url = '' + baseUrl + path;
           return (0, _nodeRequestBySwagger2.default)(obj, {
             request: args,

--- a/lib/typeMap.js
+++ b/lib/typeMap.js
@@ -46,14 +46,18 @@ var getTypeNameFromRef = function getTypeNameFromRef(ref) {
 };
 
 var getExistingType = function getExistingType(ref, isInputType, gqlTypes) {
-  var typeName = getTypeNameFromRef(ref);
+  var refTypeName = getTypeNameFromRef(ref);
+  var typeName = refTypeName;
+  if (isInputType && !typeName.endsWith('Input')) {
+    typeName = typeName + 'Input';
+  }
   var allSchema = (0, _swagger.getSchema)();
   if (!gqlTypes[typeName]) {
-    var schema = allSchema.definitions[typeName];
+    var schema = allSchema.definitions[refTypeName];
     if (!schema) {
-      throw new Error('Definition ' + typeName + ' was not found in schema');
+      throw new Error('Definition ' + refTypeName + ' was not found in schema');
     }
-    return createGQLObject(schema, typeName, isInputType, gqlTypes);
+    return createGQLObject(schema, refTypeName, isInputType, gqlTypes);
   }
   return gqlTypes[typeName];
 };
@@ -63,7 +67,12 @@ var getRefProp = function getRefProp(jsonSchema) {
 };
 
 var createGQLObject = exports.createGQLObject = function createGQLObject(jsonSchema, title, isInputType, gqlTypes) {
-  title = jsonSchema && jsonSchema.title || title; // eslint-disable-line no-param-reassign
+  title = jsonSchema && jsonSchema.title || title || ''; // eslint-disable-line no-param-reassign
+
+  if (isInputType && !title.endsWith('Input')) {
+    title = title + 'Input'; // eslint-disable-line no-param-reassign
+  }
+
   if (title in gqlTypes) {
     return gqlTypes[title];
   }
@@ -73,7 +82,7 @@ var createGQLObject = exports.createGQLObject = function createGQLObject(jsonSch
       type: 'object',
       properties: {},
       description: '',
-      title: title || ''
+      title: title
     };
   } else if (!jsonSchema.title) {
     jsonSchema.title = title;

--- a/lib/typeMap.js
+++ b/lib/typeMap.js
@@ -71,6 +71,7 @@ var createGQLObject = exports.createGQLObject = function createGQLObject(jsonSch
 
   if (isInputType && !title.endsWith('Input')) {
     title = title + 'Input'; // eslint-disable-line no-param-reassign
+    jsonSchema = _lodash2.default.clone(jsonSchema); // eslint-disable-line no-param-reassign
   }
 
   if (title in gqlTypes) {

--- a/lib/typeMap.js
+++ b/lib/typeMap.js
@@ -27,8 +27,6 @@ function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj;
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var __allTypes = {};
-
 var primitiveTypes = {
   string: graphql.GraphQLString,
   date: graphql.GraphQLString,
@@ -36,6 +34,7 @@ var primitiveTypes = {
   number: graphql.GraphQLInt,
   boolean: graphql.GraphQLBoolean
 };
+
 
 var isObjectType = function isObjectType(jsonSchema) {
   return jsonSchema.properties || jsonSchema.type === 'object' || jsonSchema.type === 'array' || jsonSchema.schema;
@@ -46,83 +45,99 @@ var getTypeNameFromRef = function getTypeNameFromRef(ref) {
   return cutRef.replace(/\//, '_');
 };
 
-var getExistingType = function getExistingType(ref, isInputType) {
+var getExistingType = function getExistingType(ref, isInputType, gqlTypes) {
   var typeName = getTypeNameFromRef(ref);
   var allSchema = (0, _swagger.getSchema)();
-  if (!__allTypes[typeName]) {
+  if (!gqlTypes[typeName]) {
     var schema = allSchema.definitions[typeName];
     if (!schema) {
       throw new Error('Definition ' + typeName + ' was not found in schema');
     }
-    __allTypes[typeName] = createGQLObject(schema, typeName, isInputType);
+    return createGQLObject(schema, typeName, isInputType, gqlTypes);
   }
-  return __allTypes[typeName];
+  return gqlTypes[typeName];
 };
 
 var getRefProp = function getRefProp(jsonSchema) {
   return jsonSchema.$ref || jsonSchema.schema && jsonSchema.schema.$ref;
 };
 
-var createGQLObject = exports.createGQLObject = function createGQLObject(jsonSchema, title, isInputType) {
+var createGQLObject = exports.createGQLObject = function createGQLObject(jsonSchema, title, isInputType, gqlTypes) {
+  title = jsonSchema && jsonSchema.title || title; // eslint-disable-line no-param-reassign
+  if (title in gqlTypes) {
+    return gqlTypes[title];
+  }
+
   if (!jsonSchema) {
     jsonSchema = { // eslint-disable-line no-param-reassign
       type: 'object',
       properties: {},
       description: '',
-      title: ''
+      title: title || ''
     };
+  } else if (!jsonSchema.title) {
+    jsonSchema.title = title;
   }
 
   var reference = getRefProp(jsonSchema);
 
   if (reference) {
-    return getExistingType(reference, isInputType);
+    return getExistingType(reference, isInputType, gqlTypes);
   }
 
   if (jsonSchema.type === 'array') {
-    if (isObjectType(jsonSchema.items)) {
-      return new graphql.GraphQLList(createGQLObject(jsonSchema.items, title + '_items', isInputType));
+    if (jsonSchema.items && jsonSchema.items.$ref) {
+      return new graphql.GraphQLList(getExistingType(jsonSchema.items.$ref, isInputType, gqlTypes));
+    } else if (isObjectType(jsonSchema.items)) {
+      return new graphql.GraphQLList(createGQLObject(jsonSchema.items, title + '_items', isInputType, gqlTypes));
     }
     return new graphql.GraphQLList(getPrimitiveTypes(jsonSchema.items));
   }
 
-  title = title || jsonSchema.title; // eslint-disable-line no-param-reassign
   var description = jsonSchema.description;
-  var fields = getTypeFields(jsonSchema, title, isInputType);
+  var fields = getTypeFields(jsonSchema, title, isInputType, gqlTypes);
+  var result = void 0;
   if (isInputType) {
-    return new graphql.GraphQLInputObjectType({
+    result = new graphql.GraphQLInputObjectType({
+      name: title,
+      description: description,
+      fields: fields
+    });
+  } else {
+    result = new graphql.GraphQLObjectType({
       name: title,
       description: description,
       fields: fields
     });
   }
-  return new graphql.GraphQLObjectType({
-    name: title,
-    description: description,
-    fields: fields
-  });
+  gqlTypes[title] = result;
+  return result;
 };
 
-var getTypeFields = exports.getTypeFields = function getTypeFields(jsonSchema, title, isInputType) {
-  var fields = _lodash2.default.mapValues(jsonSchema.properties || {}, function (propertySchema, propertyName) {
+var getTypeFields = exports.getTypeFields = function getTypeFields(jsonSchema, title, isInputType, gqlTypes) {
+  if (!(0, _keys2.default)(jsonSchema.properties || {}).length) {
     return {
-      description: propertySchema.description,
-      type: jsonSchemaTypeToGraphQL(title, propertySchema, propertyName, isInputType)
-    };
-  });
-
-  if (!(0, _keys2.default)(fields).length) {
-    fields.empty = {
-      description: 'default field',
-      type: graphql.GraphQLString
+      empty: {
+        description: 'default field',
+        type: graphql.GraphQLString
+      }
     };
   }
-  return fields;
+  return function () {
+    return _lodash2.default.mapValues(jsonSchema.properties || {}, function (propertySchema, propertyName) {
+      return {
+        description: propertySchema.description,
+        type: jsonSchemaTypeToGraphQL(title, propertySchema, propertyName, isInputType, gqlTypes)
+      };
+    });
+  };
 };
 
-var jsonSchemaTypeToGraphQL = function jsonSchemaTypeToGraphQL(title, jsonSchema, schemaName, isInputType) {
-  if (isObjectType(jsonSchema)) {
-    return createGQLObject(jsonSchema, title + '_' + schemaName, isInputType);
+var jsonSchemaTypeToGraphQL = function jsonSchemaTypeToGraphQL(title, jsonSchema, schemaName, isInputType, gqlTypes) {
+  if (jsonSchema.$ref) {
+    return getExistingType(jsonSchema.$ref, isInputType, gqlTypes);
+  } else if (isObjectType(jsonSchema)) {
+    return createGQLObject(jsonSchema, title + '_' + schemaName, isInputType, gqlTypes);
   } else if (jsonSchema.type) {
     return getPrimitiveTypes(jsonSchema);
   }
@@ -142,9 +157,9 @@ var getPrimitiveTypes = function getPrimitiveTypes(jsonSchema) {
   return type;
 };
 
-var mapParametersToFields = exports.mapParametersToFields = function mapParametersToFields(parameters, typeName) {
+var mapParametersToFields = exports.mapParametersToFields = function mapParametersToFields(parameters, typeName, gqlTypes) {
   return parameters.reduce(function (res, param) {
-    var type = jsonSchemaTypeToGraphQL('param_' + typeName, param.jsonSchema, param.name, true);
+    var type = jsonSchemaTypeToGraphQL('param_' + typeName, param.jsonSchema, param.name, true, gqlTypes);
     res[param.name] = {
       type: type
     };

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",
+    "chai": "^4.1.2",
     "eslint": "^3.19.0",
     "eslint-config-airbnb-es5": "^1.1.0",
     "eslint-plugin-react": "^6.5.0",

--- a/src/swagger.js
+++ b/src/swagger.js
@@ -41,11 +41,32 @@ export const loadSchema = (pathToSchema: string) => {
 
 const replaceOddChars = (str) => str.replace(/[^_a-zA-Z0-9]/g, '_');
 
+const getServerPath = (schema) => {
+  let server = schema.servers && Array.isArray(schema.servers) ? schema.servers[0] : schema.servers;
+  if (!server) {
+    return undefined;
+  } else if (typeof server === 'string') {
+    return server;
+  }
+  let url = server.url;
+  if (server.variables) {
+    Object.keys(server.variables).forEach(function(variable) {
+      let value = server.variables[variable];
+      if (typeof (value) === 'object') {
+        value = value.default || value.enum[0];
+      }
+      url = url.replace('{' + variable + '}', value);
+    });
+  }
+  return url;
+};
+
 /**
  * Go through schema and grab routes
  */
 export const getAllEndPoints = (schema: SwaggerSchema): {[string]: Endpoint} => {
   const allTypes = {};
+  const serverPath = getServerPath(schema);
   Object.keys(schema.paths).forEach(path => {
     const route = schema.paths[path];
     Object.keys(route).forEach(method => {
@@ -61,6 +82,7 @@ export const getAllEndPoints = (schema: SwaggerSchema): {[string]: Endpoint} => 
         description: obj.description,
         response: getSuccessResponse(obj.responses),
         request: (args: GraphQLParameters, baseUrl: string) => {
+          baseUrl = baseUrl || serverPath;  // eslint-disable-line no-param-reassign
           const url = `${baseUrl}${path}`;
           return getRequestOptions(obj, {
             request: args,

--- a/src/swagger.js
+++ b/src/swagger.js
@@ -31,15 +31,18 @@ const getSuccessResponse = (responses: Responses) => {
 };
 
 export const loadSchema = (pathToSchema: string) => {
-  const schema = refParser.dereference(pathToSchema);
-  __schema = schema;
-  return schema;
+  const schemaPromise = refParser.bundle(pathToSchema)
+    .then((schema) => {
+      __schema = schema;
+      return schema;
+    });
+  return schemaPromise;
 };
 
 const replaceOddChars = (str) => str.replace(/[^_a-zA-Z0-9]/g, '_');
 
 /**
- * Going throw schema and grab routes
+ * Go through schema and grab routes
  */
 export const getAllEndPoints = (schema: SwaggerSchema): {[string]: Endpoint} => {
   const allTypes = {};

--- a/src/typeMap.js
+++ b/src/typeMap.js
@@ -22,14 +22,18 @@ const getTypeNameFromRef = (ref: string) => {
 };
 
 const getExistingType = (ref: string, isInputType: boolean, gqlTypes: GraphQLTypeMap) => {
-  const typeName = getTypeNameFromRef(ref);
+  const refTypeName = getTypeNameFromRef(ref);
+  let typeName = refTypeName;
+  if (isInputType && !typeName.endsWith('Input')) {
+    typeName = typeName + 'Input';
+  }
   const allSchema = getSchema();
   if (!gqlTypes[typeName]) {
-    const schema = allSchema.definitions[typeName];
+    const schema = allSchema.definitions[refTypeName];
     if (!schema) {
-      throw new Error(`Definition ${typeName} was not found in schema`);
+      throw new Error(`Definition ${refTypeName} was not found in schema`);
     }
-    return createGQLObject(schema, typeName, isInputType, gqlTypes);
+    return createGQLObject(schema, refTypeName, isInputType, gqlTypes);
   }
   return gqlTypes[typeName];
 };
@@ -39,7 +43,12 @@ const getRefProp = (jsonSchema: JSONSchemaType) => {
 };
 
 export const createGQLObject = (jsonSchema: JSONSchemaType, title: string, isInputType: boolean, gqlTypes: GraphQLTypeMap): GraphQLType => {
-  title = (jsonSchema && jsonSchema.title) || title;  // eslint-disable-line no-param-reassign
+  title = (jsonSchema && jsonSchema.title) || title || '';  // eslint-disable-line no-param-reassign
+
+  if (isInputType && !title.endsWith('Input')) {
+    title = title + 'Input'; // eslint-disable-line no-param-reassign
+  }
+
   if (title in gqlTypes) {
     return gqlTypes[title];
   }
@@ -49,7 +58,7 @@ export const createGQLObject = (jsonSchema: JSONSchemaType, title: string, isInp
       type: 'object',
       properties: {},
       description: '',
-      title: title || ''
+      title: title
     };
   } else if (!jsonSchema.title) {
     jsonSchema.title = title;

--- a/src/typeMap.js
+++ b/src/typeMap.js
@@ -47,6 +47,7 @@ export const createGQLObject = (jsonSchema: JSONSchemaType, title: string, isInp
 
   if (isInputType && !title.endsWith('Input')) {
     title = title + 'Input'; // eslint-disable-line no-param-reassign
+    jsonSchema = _.clone(jsonSchema);  // eslint-disable-line no-param-reassign
   }
 
   if (title in gqlTypes) {

--- a/src/types.js
+++ b/src/types.js
@@ -23,6 +23,8 @@ export type RootGraphQLSchema = {
 
 export type GraphQLParameters = {[string]: any};
 
+export type GraphQLTypeMap = {[string]: GraphQLType};
+
 export type Endpoint = {
   parameters: Array<EndpointParam>,
   description?: string,

--- a/test/fixtures/circular.graphql
+++ b/test/fixtures/circular.graphql
@@ -1,0 +1,13 @@
+type Circular {
+  name: String
+  reference: Circular
+}
+
+type Query {
+  viewer: viewer
+}
+
+type viewer {
+  """A retrieves a circular structure"""
+  get_swagger_graphql_circular: [Circular]
+}

--- a/test/fixtures/circular.graphql
+++ b/test/fixtures/circular.graphql
@@ -3,6 +3,16 @@ type Circular {
   reference: Circular
 }
 
+input CircularInput {
+  name: String
+  reference: CircularInput
+}
+
+type Mutation {
+  """Updates a circular structure"""
+  patch_swagger_graphql_circular(body: CircularInput): [Circular]
+}
+
 type Query {
   viewer: viewer
 }

--- a/test/fixtures/circular.json
+++ b/test/fixtures/circular.json
@@ -33,6 +33,30 @@
                         }
                     }
                 }
+            },
+            "patch": {
+                "description": "Updates a circular structure",
+                "parameters": [{
+                    "in": "body",
+                    "name": "body",
+                    "schema": {
+                        "$ref": "#/definitions/Circular"
+                    }
+                }],
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": null,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Circular"
+                            }
+                        }
+                    }
+                }
             }
         }
     },

--- a/test/fixtures/circular.json
+++ b/test/fixtures/circular.json
@@ -1,0 +1,54 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "1.0.0",
+        "title": "Fake API",
+        "description": "For testing circular structures"
+    },
+    "schemes": [
+        "http"
+    ],
+    "consumes": [
+        "application/json"
+    ],
+    "produces": [
+        "application/json"
+    ],
+    "paths": {
+        "/swagger-graphql/circular": {
+            "get": {
+                "description": "A retrieves a circular structure",
+                "parameters": [],
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": null,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Circular"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "Circular": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "reference": {
+                    "schema": {
+                        "$ref": "#/definitions/Circular"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/fixtures/petstore.graphql
+++ b/test/fixtures/petstore.graphql
@@ -3,6 +3,11 @@ type addPet {
   empty: String
 }
 
+type Category {
+  id: String
+  name: String
+}
+
 input CategoryInput {
   id: String
   name: String
@@ -111,6 +116,17 @@ input param_createUsersWithListInput_bodyInput {
   empty: String
 }
 
+type Pet {
+  id: String
+  category: Category
+  name: String
+  photoUrls: [String]
+  tags: [Tag]
+
+  """pet status in the store"""
+  status: String
+}
+
 input PetInput {
   id: String
   category: CategoryInput
@@ -124,6 +140,11 @@ input PetInput {
 
 type Query {
   viewer: viewer
+}
+
+type Tag {
+  id: String
+  name: String
 }
 
 input TagInput {
@@ -146,6 +167,19 @@ type updateUser {
   empty: String
 }
 
+type User {
+  id: String
+  username: String
+  firstName: String
+  lastName: String
+  email: String
+  password: String
+  phone: String
+
+  """User Status"""
+  userStatus: Int
+}
+
 input UserInput {
   id: String
   username: String
@@ -161,15 +195,15 @@ input UserInput {
 
 type viewer {
   """Multiple status values can be provided with comma separated strings"""
-  findPetsByStatus(status: [String]): [PetInput]
+  findPetsByStatus(status: [String]): [Pet]
 
   """
   Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
   """
-  findPetsByTags(tags: [String]): [PetInput]
+  findPetsByTags(tags: [String]): [Pet]
 
   """Returns a single pet"""
-  getPetById(petId: String): PetInput
+  getPetById(petId: String): Pet
 
   """Returns a map of status codes to quantities"""
   getInventory: getInventory
@@ -180,5 +214,5 @@ type viewer {
   getOrderById(orderId: String): Order
   loginUser(username: String, password: String): loginUser
   logoutUser: logoutUser
-  getUserByName(username: String): UserInput
+  getUserByName(username: String): User
 }

--- a/test/fixtures/petstore.graphql
+++ b/test/fixtures/petstore.graphql
@@ -1,0 +1,173 @@
+type addPet {
+  """default field"""
+  empty: String
+}
+
+input Category {
+  id: String
+  name: String
+}
+
+type createUser {
+  """default field"""
+  empty: String
+}
+
+type createUsersWithArrayInput {
+  """default field"""
+  empty: String
+}
+
+type createUsersWithListInput {
+  """default field"""
+  empty: String
+}
+
+type deleteOrder {
+  """default field"""
+  empty: String
+}
+
+type deletePet {
+  """default field"""
+  empty: String
+}
+
+type deleteUser {
+  """default field"""
+  empty: String
+}
+
+type getInventory {
+  """default field"""
+  empty: String
+}
+
+type loginUser {
+  """default field"""
+  empty: String
+}
+
+type logoutUser {
+  """default field"""
+  empty: String
+}
+
+type Mutation {
+  addPet(body: Pet): addPet
+  updatePet(body: Pet): updatePet
+  updatePetWithForm(petId: String, name: String, status: String): updatePetWithForm
+  deletePet(api_key: String, petId: String): deletePet
+  placeOrder(body: Order): Order
+
+  """
+  For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors
+  """
+  deleteOrder(orderId: String): deleteOrder
+
+  """This can only be done by the logged in user."""
+  createUser(body: User): createUser
+  createUsersWithArrayInput(body: param_createUsersWithArrayInput_body): createUsersWithArrayInput
+  createUsersWithListInput(body: param_createUsersWithListInput_body): createUsersWithListInput
+
+  """This can only be done by the logged in user."""
+  updateUser(username: String, body: User): updateUser
+
+  """This can only be done by the logged in user."""
+  deleteUser(username: String): deleteUser
+}
+
+type Order {
+  id: String
+  petId: String
+  quantity: Int
+  shipDate: String
+
+  """Order Status"""
+  status: String
+  complete: Boolean
+}
+
+"""List of user object"""
+input param_createUsersWithArrayInput_body {
+  """default field"""
+  empty: String
+}
+
+"""List of user object"""
+input param_createUsersWithListInput_body {
+  """default field"""
+  empty: String
+}
+
+input Pet {
+  id: String
+  category: Category
+  name: String
+  photoUrls: [String]
+  tags: [Tag]
+
+  """pet status in the store"""
+  status: String
+}
+
+type Query {
+  viewer: viewer
+}
+
+input Tag {
+  id: String
+  name: String
+}
+
+type updatePet {
+  """default field"""
+  empty: String
+}
+
+type updatePetWithForm {
+  """default field"""
+  empty: String
+}
+
+type updateUser {
+  """default field"""
+  empty: String
+}
+
+input User {
+  id: String
+  username: String
+  firstName: String
+  lastName: String
+  email: String
+  password: String
+  phone: String
+
+  """User Status"""
+  userStatus: Int
+}
+
+type viewer {
+  """Multiple status values can be provided with comma separated strings"""
+  findPetsByStatus(status: [String]): [Pet]
+
+  """
+  Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+  """
+  findPetsByTags(tags: [String]): [Pet]
+
+  """Returns a single pet"""
+  getPetById(petId: String): Pet
+
+  """Returns a map of status codes to quantities"""
+  getInventory: getInventory
+
+  """
+  For valid response try integer IDs with value >= 1 and <= 10. Other values will generated exceptions
+  """
+  getOrderById(orderId: String): Order
+  loginUser(username: String, password: String): loginUser
+  logoutUser: logoutUser
+  getUserByName(username: String): User
+}

--- a/test/fixtures/petstore.graphql
+++ b/test/fixtures/petstore.graphql
@@ -3,7 +3,7 @@ type addPet {
   empty: String
 }
 
-input Category {
+input CategoryInput {
   id: String
   name: String
 }
@@ -54,11 +54,11 @@ type logoutUser {
 }
 
 type Mutation {
-  addPet(body: Pet): addPet
-  updatePet(body: Pet): updatePet
+  addPet(body: PetInput): addPet
+  updatePet(body: PetInput): updatePet
   updatePetWithForm(petId: String, name: String, status: String): updatePetWithForm
   deletePet(api_key: String, petId: String): deletePet
-  placeOrder(body: Order): Order
+  placeOrder(body: OrderInput): Order
 
   """
   For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors
@@ -66,12 +66,12 @@ type Mutation {
   deleteOrder(orderId: String): deleteOrder
 
   """This can only be done by the logged in user."""
-  createUser(body: User): createUser
-  createUsersWithArrayInput(body: param_createUsersWithArrayInput_body): createUsersWithArrayInput
-  createUsersWithListInput(body: param_createUsersWithListInput_body): createUsersWithListInput
+  createUser(body: UserInput): createUser
+  createUsersWithArrayInput(body: param_createUsersWithArrayInput_bodyInput): createUsersWithArrayInput
+  createUsersWithListInput(body: param_createUsersWithListInput_bodyInput): createUsersWithListInput
 
   """This can only be done by the logged in user."""
-  updateUser(username: String, body: User): updateUser
+  updateUser(username: String, body: UserInput): updateUser
 
   """This can only be done by the logged in user."""
   deleteUser(username: String): deleteUser
@@ -88,24 +88,35 @@ type Order {
   complete: Boolean
 }
 
-"""List of user object"""
-input param_createUsersWithArrayInput_body {
-  """default field"""
-  empty: String
-}
-
-"""List of user object"""
-input param_createUsersWithListInput_body {
-  """default field"""
-  empty: String
-}
-
-input Pet {
+input OrderInput {
   id: String
-  category: Category
+  petId: String
+  quantity: Int
+  shipDate: String
+
+  """Order Status"""
+  status: String
+  complete: Boolean
+}
+
+"""List of user object"""
+input param_createUsersWithArrayInput_bodyInput {
+  """default field"""
+  empty: String
+}
+
+"""List of user object"""
+input param_createUsersWithListInput_bodyInput {
+  """default field"""
+  empty: String
+}
+
+input PetInput {
+  id: String
+  category: CategoryInput
   name: String
   photoUrls: [String]
-  tags: [Tag]
+  tags: [TagInput]
 
   """pet status in the store"""
   status: String
@@ -115,7 +126,7 @@ type Query {
   viewer: viewer
 }
 
-input Tag {
+input TagInput {
   id: String
   name: String
 }
@@ -135,7 +146,7 @@ type updateUser {
   empty: String
 }
 
-input User {
+input UserInput {
   id: String
   username: String
   firstName: String
@@ -150,15 +161,15 @@ input User {
 
 type viewer {
   """Multiple status values can be provided with comma separated strings"""
-  findPetsByStatus(status: [String]): [Pet]
+  findPetsByStatus(status: [String]): [PetInput]
 
   """
   Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
   """
-  findPetsByTags(tags: [String]): [Pet]
+  findPetsByTags(tags: [String]): [PetInput]
 
   """Returns a single pet"""
-  getPetById(petId: String): Pet
+  getPetById(petId: String): PetInput
 
   """Returns a map of status codes to quantities"""
   getInventory: getInventory
@@ -169,5 +180,5 @@ type viewer {
   getOrderById(orderId: String): Order
   loginUser(username: String, password: String): loginUser
   logoutUser: logoutUser
-  getUserByName(username: String): User
+  getUserByName(username: String): UserInput
 }

--- a/test/fixtures/petstore.graphql.old
+++ b/test/fixtures/petstore.graphql.old
@@ -1,0 +1,257 @@
+type addPet {
+  """default field"""
+  empty: String
+}
+
+type createUser {
+  """default field"""
+  empty: String
+}
+
+type createUsersWithArrayInput {
+  """default field"""
+  empty: String
+}
+
+type createUsersWithListInput {
+  """default field"""
+  empty: String
+}
+
+type deleteOrder {
+  """default field"""
+  empty: String
+}
+
+type deletePet {
+  """default field"""
+  empty: String
+}
+
+type deleteUser {
+  """default field"""
+  empty: String
+}
+
+type findPetsByStatus_items {
+  id: String
+  category: findPetsByStatus_items_category
+  name: String
+  photoUrls: [String]
+  tags: [findPetsByStatus_items_tags_items]
+
+  """pet status in the store"""
+  status: String
+}
+
+type findPetsByStatus_items_category {
+  id: String
+  name: String
+}
+
+type findPetsByStatus_items_tags_items {
+  id: String
+  name: String
+}
+
+type findPetsByTags_items {
+  id: String
+  category: findPetsByTags_items_category
+  name: String
+  photoUrls: [String]
+  tags: [findPetsByTags_items_tags_items]
+
+  """pet status in the store"""
+  status: String
+}
+
+type findPetsByTags_items_category {
+  id: String
+  name: String
+}
+
+type findPetsByTags_items_tags_items {
+  id: String
+  name: String
+}
+
+type getInventory {
+  """default field"""
+  empty: String
+}
+
+type getOrderById {
+  id: String
+  petId: String
+  quantity: Int
+  shipDate: String
+
+  """Order Status"""
+  status: String
+  complete: Boolean
+}
+
+type getPetById {
+  id: String
+  category: getPetById_category
+  name: String
+  photoUrls: [String]
+  tags: [getPetById_tags_items]
+
+  """pet status in the store"""
+  status: String
+}
+
+type getPetById_category {
+  id: String
+  name: String
+}
+
+type getPetById_tags_items {
+  id: String
+  name: String
+}
+
+type getUserByName {
+  id: String
+  username: String
+  firstName: String
+  lastName: String
+  email: String
+  password: String
+  phone: String
+
+  """User Status"""
+  userStatus: Int
+}
+
+type loginUser {
+  """default field"""
+  empty: String
+}
+
+type logoutUser {
+  """default field"""
+  empty: String
+}
+
+type Mutation {
+  addPet(body: param_addPet_body): addPet
+  updatePet(body: param_updatePet_body): updatePet
+  updatePetWithForm(petId: String, name: String, status: String): updatePetWithForm
+  deletePet(api_key: String, petId: String): deletePet
+  placeOrder(body: param_placeOrder_body): placeOrder
+
+  """
+  For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors
+  """
+  deleteOrder(orderId: String): deleteOrder
+
+  """This can only be done by the logged in user."""
+  createUser(body: param_createUser_body): createUser
+  createUsersWithArrayInput(body: param_createUsersWithArrayInput_body): createUsersWithArrayInput
+  createUsersWithListInput(body: param_createUsersWithListInput_body): createUsersWithListInput
+
+  """This can only be done by the logged in user."""
+  updateUser(username: String, body: param_updateUser_body): updateUser
+
+  """This can only be done by the logged in user."""
+  deleteUser(username: String): deleteUser
+}
+
+"""Pet object that needs to be added to the store"""
+input param_addPet_body {
+  """default field"""
+  empty: String
+}
+
+"""Created user object"""
+input param_createUser_body {
+  """default field"""
+  empty: String
+}
+
+"""List of user object"""
+input param_createUsersWithArrayInput_body {
+  """default field"""
+  empty: String
+}
+
+"""List of user object"""
+input param_createUsersWithListInput_body {
+  """default field"""
+  empty: String
+}
+
+"""order placed for purchasing the pet"""
+input param_placeOrder_body {
+  """default field"""
+  empty: String
+}
+
+"""Pet object that needs to be added to the store"""
+input param_updatePet_body {
+  """default field"""
+  empty: String
+}
+
+"""Updated user object"""
+input param_updateUser_body {
+  """default field"""
+  empty: String
+}
+
+type placeOrder {
+  id: String
+  petId: String
+  quantity: Int
+  shipDate: String
+
+  """Order Status"""
+  status: String
+  complete: Boolean
+}
+
+type Query {
+  viewer: viewer
+}
+
+type updatePet {
+  """default field"""
+  empty: String
+}
+
+type updatePetWithForm {
+  """default field"""
+  empty: String
+}
+
+type updateUser {
+  """default field"""
+  empty: String
+}
+
+type viewer {
+  """Multiple status values can be provided with comma separated strings"""
+  findPetsByStatus(status: [String]): [findPetsByStatus_items]
+
+  """
+  Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+  """
+  findPetsByTags(tags: [String]): [findPetsByTags_items]
+
+  """Returns a single pet"""
+  getPetById(petId: String): getPetById
+
+  """Returns a map of status codes to quantities"""
+  getInventory: getInventory
+
+  """
+  For valid response try integer IDs with value >= 1 and <= 10. Other values will generated exceptions
+  """
+  getOrderById(orderId: String): getOrderById
+  loginUser(username: String, password: String): loginUser
+  logoutUser: logoutUser
+  getUserByName(username: String): getUserByName
+}
+

--- a/test/index.js
+++ b/test/index.js
@@ -12,7 +12,7 @@ describe('Test Cases', () => {
           .then((schema) => {
             const graphqlfile = directory + (file.replace('.json', '.graphql'));
             const graphschema = graphql.printSchema(schema);
-            const expected = fs.readFileSync(graphqlfile, "utf8");
+            const expected = fs.readFileSync(graphqlfile, 'utf8');
 
             expect(graphschema).to.equal(expected);
           });

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,22 @@
 const graphQLSchema = require('../lib');
+const graphql = require('graphql');
+const fs = require('fs');
+const expect = require('chai').expect;
 
-describe('petstore schema', () => {
-  it('converting', (done) => {
-    graphQLSchema(`${__dirname}/fixtures/petstore.json`).then(() => done()).catch(done);
+describe('Test Cases', () => {
+  const directory = `${__dirname}/fixtures/`;
+  fs.readdirSync(directory).forEach(file => {
+    if (file.endsWith('.json')) {
+      it(file, () => {
+        return graphQLSchema(directory + file)
+          .then((schema) => {
+            const graphqlfile = directory + (file.replace('.json', '.graphql'));
+            const graphschema = graphql.printSchema(schema);
+            const expected = fs.readFileSync(graphqlfile, "utf8");
+
+            expect(graphschema).to.equal(expected);
+          });
+      });
+    }
   });
 });


### PR DESCRIPTION
This fixes https://github.com/yarax/swagger-to-graphql/issues/33 and https://github.com/yarax/swagger-to-graphql/issues/51

The issue wasnt the loading, it was when you try and convert object definitions, you change the name and add a prefix, so it appears like a new object. Furthermore, you dont track the objects you've added already. So, even though loading the structure worked, the conversion had an infinite loop. I've updated the test framework because the test currently only checked that there wasnt an error, it didnt check for correctness. So, I've updated it to check that the output is correct and I've added a test for a circular dependency.

Next, the ref parser removed the refs from the object structure, so none of those definitions were ever used and produced very odd results. I've changed it so that the ref parser doesnt replace the refs since we handle them manually in the code.

The above two things have caused quite a large change in the output of the code. To see the difference compare test/fixtures/petstore.graphql and test/fixtures/petstore.graphql.old (which is what the code produced before this PR).