### PR TITLE
Consider number type to be equivalent to GraphQLFloat

### DIFF
--- a/src/typeMap.js
+++ b/src/typeMap.js
@@ -9,7 +9,7 @@ const primitiveTypes = {
   string: graphql.GraphQLString,
   date: graphql.GraphQLString,
   integer: graphql.GraphQLInt,
-  number: graphql.GraphQLInt,
+  number: graphql.GraphQLFloat,
   boolean: graphql.GraphQLBoolean
 };
 


### PR DESCRIPTION
Currently Swagger type number is considered to be GraphQLInt type, which is incorrect and will lead to errors. 
Instead this should be GraphQLFloat