### PR TITLE
Don't proxy host header

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,8 @@ const resolver = (endpoint: Endpoint, proxyUrl: ?(Function | string), customHead
     const proxy = !proxyUrl ? opts.GQLProxyBaseUrl : (typeof proxyUrl === 'function' ? proxyUrl(opts) : proxyUrl);
     const req = endpoint.request(args, proxy);
     if (opts.headers) {
-      req.headers = Object.assign(customHeaders, req.headers, opts.headers);
+      const { host, ...otherHeaders } = opts.headers;
+      req.headers = Object.assign(customHeaders, req.headers, otherHeaders);
     }
     const res = await rp(req);
     return JSON.parse(res);


### PR DESCRIPTION
The host header sent to the graphql server should not be same as the host
header sent from graphql to the actual backend. This causes issues with SSL and
servers which are using virtual hosts.