### PR TITLE
Corrected npm run start call for app.js

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "main": "index.js",
   "scripts": {
-    "start": "node example.js"
+    "start": "node app.js"
   },
   "dependencies": {
     "babel-polyfill": "^6.23.0",


### PR DESCRIPTION
Corrected npm run start call for app.js, because no example.js does exist.