### PR TITLE
Fix custom headers if context passed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,10 +37,8 @@ const resolver = (endpoint: Endpoint, proxyUrl: ?(Function | string), customHead
   async (_, args: GraphQLParameters, opts: SwaggerToGraphQLOptions) => {
     const proxy = !proxyUrl ? opts.GQLProxyBaseUrl : (typeof proxyUrl === 'function' ? proxyUrl(opts) : proxyUrl);
     const req = endpoint.request(args, proxy);
-    if (opts.headers) {
-      const { host, ...otherHeaders } = opts.headers;
-      req.headers = Object.assign(customHeaders, req.headers, otherHeaders);
-    }
+    const  { host, ...otherHeaders } = opts.headers ? opts.headers : {};
+    req.headers = { ...customHeaders, ...req.headers, ...otherHeaders };
     const res = await rp(req);
     return JSON.parse(res);
   };


### PR DESCRIPTION
If custom `context` passed to `express-graphql` [here](https://github.com/yarax/swagger-to-graphql/blob/master/example/app.js#L14) and it doesn't have `headers` field, customHeaders will be completely ignored.

```js
app.use('/graphql', graphqlHTTP(() => {
    return {
      schema,
      context: { foo: "bar" },
      graphiql: true
    };
  }));
```
customHeaders merged to the request if context is ommited, because `express-graphql` [passes](https://github.com/graphql/express-graphql#options) request object as a value in this case. 

This PR fixes the issue.