### PR TITLE
Fix for when parameters is a child of route and not of route[method]

### DIFF
--- a/src/swagger.js
+++ b/src/swagger.js
@@ -97,13 +97,23 @@ export const getAllEndPoints = (schema: SwaggerSchema, refs: RefType): {[string]
       const isMutation = ['post', 'put', 'patch', 'delete'].indexOf(method) !== -1;
       const typeName = obj.operationId || getGQLTypeNameFromURL(method, path);
       let parameterDetails;
+      
+      // [FIX] for when parameters is a child of route and not route[method]
+      if (route.parameters) {
+        if (obj.parameters) {
+          obj.parameters = route.parameters.concat(obj.parameters)
+        } else {
+          obj.parameters = route.parameters
+        }
+      }
+      //
+      
       if (obj.parameters) {
         parameterDetails = obj.parameters.map(param => getParamDetails(param, schema, refs));
-      } else if (route.parameters) { // Fix for when parameters is a child of route and not route[method]
-        parameterDetails = route.parameters.map(param => getParamDetails(param, schema, refs));
       } else {
         parameterDetails = [];
       }
+      
       const endpoint: Endpoint = {
         parameters: parameterDetails,
         description: obj.description,

--- a/src/swagger.js
+++ b/src/swagger.js
@@ -96,7 +96,14 @@ export const getAllEndPoints = (schema: SwaggerSchema, refs: RefType): {[string]
       const obj = route[method];
       const isMutation = ['post', 'put', 'patch', 'delete'].indexOf(method) !== -1;
       const typeName = obj.operationId || getGQLTypeNameFromURL(method, path);
-      const parameterDetails = obj.parameters ? obj.parameters.map(param => getParamDetails(param, schema, refs)) : [];
+      let parameterDetails;
+      if (obj.parameters) {
+        parameterDetails = obj.parameters.map(param => getParamDetails(param, schema, refs));
+      } else if (route.parameters) { // Fix for when parameters is a child of route and not route[method]
+        parameterDetails = route.parameters.map(param => getParamDetails(param, schema, refs));
+      } else {
+        parameterDetails = [];
+      }
       const endpoint: Endpoint = {
         parameters: parameterDetails,
         description: obj.description,


### PR DESCRIPTION
For an exemple of a valid OpenApi spec file that cause the bug, please see: https://raw.githubusercontent.com/APIs-guru/openapi-directory/master/APIs/twitter.com/1.1/swagger.yaml

Parameters field is a child of Path and not of Path.Method