### PR TITLE
Add `files` field to `package.json`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "graphql",
     "swagger"
   ],
+  "files": ["bin", "lib"],
   "license": "MIT",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
To prevent unnecessary files (tests, `yarn.lock`, `package-lock.json`, et cetera) from being published to NPM.  A `.npmignore` would also work.