### PR TITLE
Use JSONObject scalar for objects with unknown fields

### DIFF
--- a/lib/typeMap.js
+++ b/lib/typeMap.js
@@ -13,6 +13,8 @@ var _keys = require('babel-runtime/core-js/object/keys');
 
 var _keys2 = _interopRequireDefault(_keys);
 
+var _graphqlTypeJson = require('graphql-type-json');
+
 var _lodash = require('lodash');
 
 var _lodash2 = _interopRequireDefault(_lodash);
@@ -34,7 +36,6 @@ var primitiveTypes = {
   number: graphql.GraphQLFloat,
   boolean: graphql.GraphQLBoolean
 };
-
 
 var isObjectType = function isObjectType(jsonSchema) {
   return jsonSchema.properties || jsonSchema.type === 'object' || jsonSchema.type === 'array' || jsonSchema.schema;
@@ -112,7 +113,9 @@ var createGQLObject = exports.createGQLObject = function createGQLObject(jsonSch
   var description = jsonSchema.description;
   var fields = getTypeFields(jsonSchema, title, isInputType, gqlTypes);
   var result = void 0;
-  if (isInputType) {
+  if (!jsonSchema || !fields) {
+    result = _graphqlTypeJson.GraphQLJSONObject;
+  } else if (isInputType) {
     result = new graphql.GraphQLInputObjectType({
       name: title,
       description: description,
@@ -131,12 +134,7 @@ var createGQLObject = exports.createGQLObject = function createGQLObject(jsonSch
 
 var getTypeFields = exports.getTypeFields = function getTypeFields(jsonSchema, title, isInputType, gqlTypes) {
   if (!(0, _keys2.default)(jsonSchema.properties || {}).length) {
-    return {
-      empty: {
-        description: 'default field',
-        type: graphql.GraphQLString
-      }
-    };
+    return null;
   }
   return function () {
     var properties = {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -3405,6 +3405,11 @@
         "iterall": "^1.2.2"
       }
     },
+    "graphql-type-json": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.3.0.tgz",
+      "integrity": "sha512-lnxg5HiB95yxy+/5cDKtP6pZo0zgntsOmqsjeCBXFGJ4YoMF3+1YaSEKWJntNTu+VsAm3zf6lPxFpp1kxzofLA=="
+    },
     "growl": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "babel-runtime": "^6.25.0",
     "graphql": "^14.1.1",
+    "graphql-type-json": "^0.3.0",
     "isomorphic-fetch": "^2.2.1",
     "js-yaml": "^3.8.4",
     "json-schema-ref-parser": "^3.1.2",

--- a/src/typeMap.js
+++ b/src/typeMap.js
@@ -1,6 +1,7 @@
 // @flow
 import type {GraphQLType, JSONSchemaType, EndpointParam, GraphQLTypeMap} from './types';
 import type {GraphQLScalarType} from 'graphql/type/definition.js.flow';
+import { GraphQLJSONObject } from 'graphql-type-json';
 import _ from 'lodash';
 import * as graphql from 'graphql';
 import {getSchema} from './swagger';
@@ -86,7 +87,9 @@ export const createGQLObject = (jsonSchema: JSONSchemaType, title: string, isInp
   const description = jsonSchema.description;
   const fields = getTypeFields(jsonSchema, title, isInputType, gqlTypes);
   let result;
-  if (isInputType) {
+  if (!jsonSchema || !fields) {
+    result = GraphQLJSONObject;
+  } else if (isInputType) {
     result = new graphql.GraphQLInputObjectType({
       name: title,
       description,
@@ -106,12 +109,7 @@ export const createGQLObject = (jsonSchema: JSONSchemaType, title: string, isInp
 
 export const getTypeFields = (jsonSchema: JSONSchemaType, title: string, isInputType: boolean, gqlTypes: GraphQLTypeMap) => {
   if (!Object.keys(jsonSchema.properties || {}).length) {
-    return {
-      empty: {
-        description: 'default field',
-        type: graphql.GraphQLString
-      }
-    };
+    return null;
   }
   return () => {
     const properties = {};

--- a/test/fixtures/petstore.graphql
+++ b/test/fixtures/petstore.graphql
@@ -1,8 +1,3 @@
-type addPet {
-  """default field"""
-  empty: String
-}
-
 type Category {
   id: String
   name: String
@@ -13,73 +8,33 @@ input CategoryInput {
   name: String
 }
 
-type createUser {
-  """default field"""
-  empty: String
-}
-
-type createUsersWithArrayInput {
-  """default field"""
-  empty: String
-}
-
-type createUsersWithListInput {
-  """default field"""
-  empty: String
-}
-
-type deleteOrder {
-  """default field"""
-  empty: String
-}
-
-type deletePet {
-  """default field"""
-  empty: String
-}
-
-type deleteUser {
-  """default field"""
-  empty: String
-}
-
-type getInventory {
-  """default field"""
-  empty: String
-}
-
-type loginUser {
-  """default field"""
-  empty: String
-}
-
-type logoutUser {
-  """default field"""
-  empty: String
-}
+"""
+The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+"""
+scalar JSONObject
 
 type Mutation {
-  addPet(body: PetInput!): addPet!
-  updatePet(body: PetInput!): updatePet!
-  updatePetWithForm(petId: String!, name: String, status: String): updatePetWithForm!
-  deletePet(api_key: String, petId: String!): deletePet!
+  addPet(body: PetInput!): JSONObject!
+  updatePet(body: PetInput!): JSONObject!
+  updatePetWithForm(petId: String!, name: String, status: String): JSONObject!
+  deletePet(api_key: String, petId: String!): JSONObject!
   placeOrder(body: OrderInput!): Order!
 
   """
   For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors
   """
-  deleteOrder(orderId: String!): deleteOrder!
+  deleteOrder(orderId: String!): JSONObject!
 
   """This can only be done by the logged in user."""
-  createUser(body: UserInput!): createUser!
-  createUsersWithArrayInput(body: param_createUsersWithArrayInput_bodyInput!): createUsersWithArrayInput!
-  createUsersWithListInput(body: param_createUsersWithListInput_bodyInput!): createUsersWithListInput!
+  createUser(body: UserInput!): JSONObject!
+  createUsersWithArrayInput(body: JSONObject!): JSONObject!
+  createUsersWithListInput(body: JSONObject!): JSONObject!
 
   """This can only be done by the logged in user."""
-  updateUser(username: String!, body: UserInput!): updateUser!
+  updateUser(username: String!, body: UserInput!): JSONObject!
 
   """This can only be done by the logged in user."""
-  deleteUser(username: String!): deleteUser!
+  deleteUser(username: String!): JSONObject!
 }
 
 type Order {
@@ -102,18 +57,6 @@ input OrderInput {
   """Order Status"""
   status: String
   complete: Boolean
-}
-
-"""List of user object"""
-input param_createUsersWithArrayInput_bodyInput {
-  """default field"""
-  empty: String
-}
-
-"""List of user object"""
-input param_createUsersWithListInput_bodyInput {
-  """default field"""
-  empty: String
 }
 
 type Pet {
@@ -151,14 +94,14 @@ type Query {
   getPetById(petId: String!): Pet!
 
   """Returns a map of status codes to quantities"""
-  getInventory: getInventory!
+  getInventory: JSONObject!
 
   """
   For valid response try integer IDs with value >= 1 and <= 10. Other values will generated exceptions
   """
   getOrderById(orderId: String!): Order!
-  loginUser(username: String!, password: String!): loginUser!
-  logoutUser: logoutUser!
+  loginUser(username: String!, password: String!): JSONObject!
+  logoutUser: JSONObject!
   getUserByName(username: String!): User!
 }
 
@@ -170,21 +113,6 @@ type Tag {
 input TagInput {
   id: String
   name: String
-}
-
-type updatePet {
-  """default field"""
-  empty: String
-}
-
-type updatePetWithForm {
-  """default field"""
-  empty: String
-}
-
-type updateUser {
-  """default field"""
-  empty: String
 }
 
 type User {


### PR DESCRIPTION
`empty: string` looks like a workaround and I think its better to use `JSONObject` scalar which is supported in different projects in GraphQL space.