### PR TITLE
Handle paths without success responses (again)

### DIFF
--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -30,6 +30,10 @@ export interface Responses {
 export const getSuccessResponse = (
   responses: Responses,
 ): JSONSchemaType | undefined => {
+  if (!responses) {
+    return undefined;
+  }
+  
   const successCode = Object.keys(responses).find(code => {
     return code[0] === '2';
   });

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -33,7 +33,7 @@ export const getSuccessResponse = (
   if (!responses) {
     return undefined;
   }
-  
+
   const successCode = Object.keys(responses).find(code => {
     return code[0] === '2';
   });


### PR DESCRIPTION
This check was added in 601ac79680d293052a999ecee92de058d78441e0 to fix #20 and fix #15, but was removed in 21a37357b7dd6c1f4dd575c24aaa8ce95e433b02.